### PR TITLE
Switch from GET to HEAD request

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub async fn is_url_reachable(url: &str) -> bool {
     });
 
     let client = Client::new();
-    match client.get(url).send().await {
+    match client.head(url).send().await {
         Ok(response) => {
             if response.status().is_success() {
                 debug!("URL is reachable: {}", url);


### PR DESCRIPTION
This should check validity & status without downloading the actual data. Should be just as effective at detecting errors, especially since we aren't actually using the data.